### PR TITLE
Support action in workflows with a container

### DIFF
--- a/.github/bin/create-pages.sh
+++ b/.github/bin/create-pages.sh
@@ -45,7 +45,7 @@ cd ${CONFLUENZA_PATH}
 [ -z "$PREFIX_PATH" ] && yarn build || yarn build:prefix-paths
 cd ../..
 
-printHeader "Copy to public to root"
+printHeader "Copy public to root"
 mv ${CONFLUENZA_PATH}/public public
 
 printHeader "Cleanup"

--- a/.github/workflows/gh-pages-docker.yaml
+++ b/.github/workflows/gh-pages-docker.yaml
@@ -1,0 +1,32 @@
+name: GH Pages docker
+
+on:
+  push:
+    branches: 
+      - docker
+  pull_request:
+    branches:
+      - docker
+  workflow_dispatch:
+
+jobs:
+  publish-pages-docker:
+    name: Deploy GH-pages docker
+    runs-on: ubuntu-latest
+    container: philipssoftware/node:16
+
+    steps:
+    - name: Check out code 🛎️
+      uses: actions/checkout@v2
+    - name: Create confluenza pages 📦 
+      uses: confluenza/confluenza-action@docker
+      env:
+        PREFIX_PATH: true
+    - name: Install rsync
+      run: apt-get update && apt-get install -y rsync && apt-get clean
+    - name: Deploy 🚀
+      uses: JamesIves/github-pages-deploy-action@4.1.4
+      with:
+        branch: gh-pages
+        folder: public
+        CLEAN: true

--- a/README.md
+++ b/README.md
@@ -71,5 +71,26 @@ If it exists, it will be copied.
       CLEAN: true
  ```
 
+### GitHub Workflow in a container
+
+```
+    container: node:16
+
+    steps:
+    - name: Check out code 🛎️
+      uses: actions/checkout@v2
+    - name: Create confluenza pages 📦
+      uses: confluenza/confluenza-action@docker
+      env:
+        PREFIX_PATH: true
+    - name: Install rsync
+      run: apt-get update && apt-get install -y rsync && apt-get clean
+    - name: Deploy 🚀
+      uses: JamesIves/github-pages-deploy-action@4.1.4
+      with:
+        branch: gh-pages
+        folder: public
+        CLEAN: true
+```
 ## License
 MIT

--- a/action.yml
+++ b/action.yml
@@ -9,5 +9,5 @@ runs:
   using: "composite"
   steps:
     - name: Create public folder
-      run: ${{ github.action_path }}/.github/bin/create-pages.sh
+      run: $GITHUB_ACTION_PATH/.github/bin/create-pages.sh
       shell: bash


### PR DESCRIPTION
When using the action in a container instead of on `ubuntu-latest` it failed.

GitHub has a bug, `${{github.action_path}}` is not set properly when using in combination with a container.

## Test
I've added two test deploy workflows. One with `ubuntu-latest` and one with a container.

## Documentation
Added the example in the readme.

## Related GitHub community post
https://github.community/t/when-running-a-composite-action-you-can-not-access-scripts-when-running-in-a-container-github-action-path-is-set-but-incorrect/211696/2